### PR TITLE
Refactor to use less dom queries.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import OptionsContainer from "./components/OptionsContainer";
 import Minimap from "./components/MinimapContainer/MinimapContainer";
-import { queryAllChatElements, queryChatContainer, queryChatScrollContainer, queryNavElement } from "./utils/renderLogic";
+import { queryAllChatElements, queryChatContainer, queryNavElement } from "./utils/renderLogic";
 
 export default function App() {
   const [showMinimap, setShowMinimap] = useState<boolean>(false);
   const [manualRefresh, setManualRefresh] = useState<boolean>(false); 
   const chatContainer = useRef<HTMLElement|null>(null);
+  const scrollContainer = useRef<HTMLElement|null>(null);
 
   function triggerCanvasRefresh() {
     setManualRefresh(temp => !temp)
@@ -24,6 +25,9 @@ export default function App() {
           triggerCanvasRefresh()
         }
         chatContainer.current = newChat
+        if (newChat) {
+          scrollContainer.current = newChat.parentElement
+        }
       }, 500)
     });
   }, []);
@@ -56,11 +60,11 @@ export default function App() {
       <OptionsContainer
         onToggleMinimap={onToggleMinimap}
         onRefreshMinimap={onRefreshMinimap}
-        onNextChat={onNextChat}
-        onPreviousChat={onPreviousChat}
+        onNextChat={() => onNextChat(scrollContainer.current)}
+        onPreviousChat={() => onPreviousChat(scrollContainer.current)}
         showMinimap={showMinimap}
       />
-      {showMinimap ? <Minimap refreshMinimap={manualRefresh} /> : null}
+      {showMinimap ? <Minimap refreshMinimap={manualRefresh} chatContainer={chatContainer.current} scrollContainer={scrollContainer.current} /> : null}
     </div>
   );
 }
@@ -86,8 +90,7 @@ function addLocationObserver(callback: MutationCallback) {
 }
 
 
-const onNextChat = () => {
-  const scrollContainer = queryChatScrollContainer()
+const onNextChat = (scrollContainer: HTMLElement|null) => {
   const navElement = queryNavElement()
   if (!scrollContainer || !navElement) return 
   const navHeight = navElement.offsetHeight;
@@ -99,8 +102,7 @@ const onNextChat = () => {
   const firstNextChat = nextChats[0];
   scrollContainer.scrollTo(0, scrollContainer.scrollTop + firstNextChat.getBoundingClientRect().top - navHeight)
 }
-const onPreviousChat = () => {
-  const scrollContainer = queryChatScrollContainer()
+const onPreviousChat = (scrollContainer: HTMLElement|null) => {
   const navElement = queryNavElement()
   if (!scrollContainer || !navElement) return 
   const navHeight = navElement.offsetHeight;

--- a/src/components/MinimapContainer/CanvasContainer/CanvasContainer.tsx
+++ b/src/components/MinimapContainer/CanvasContainer/CanvasContainer.tsx
@@ -1,18 +1,18 @@
 import { memo, useEffect, useRef } from "react";
-import { generateMinimapCanvas, queryChatContainer } from "../../../utils/renderLogic";
+import { generateMinimapCanvas } from "../../../utils/renderLogic";
 
 interface CanvasContainerProps {
   refreshCanvas: boolean;
   setScale: CallableFunction;
+  chatContainer: HTMLElement|null;
 }
 
-const CanvasContainer = ({ refreshCanvas, setScale }: CanvasContainerProps) => {
+const CanvasContainer = ({ refreshCanvas, setScale, chatContainer }: CanvasContainerProps) => {
   const canvasContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     console.log("canvase rerendered");
     (async () => {
-      const chatContainer = queryChatContainer();
       const canvasContainer = canvasContainerRef.current;
       if (!chatContainer || !canvasContainer) return;
       const canvas = await generateMinimapCanvas(chatContainer);
@@ -24,7 +24,7 @@ const CanvasContainer = ({ refreshCanvas, setScale }: CanvasContainerProps) => {
       canvas.style.width = `${canvasContainer.offsetWidth}px`;
       canvas.style.height = `${scale * canvas.offsetHeight}px`;
     })();
-  }, [refreshCanvas, setScale]);
+  }, [refreshCanvas, setScale, chatContainer]);
 
   return (
     <div

--- a/src/components/MinimapContainer/MinimapContainer.tsx
+++ b/src/components/MinimapContainer/MinimapContainer.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
-import {
-  queryChatScrollContainer,
-} from "../../utils/renderLogic";
 import ViewOverlay from "./ViewOverlay/ViewOverlay";
 import CanvasContainer from "./CanvasContainer/CanvasContainer";
 
 interface MinimapProps {
-  refreshMinimap: boolean
+  refreshMinimap: boolean;
+  chatContainer: HTMLElement|null;
+  scrollContainer: HTMLElement|null;
 }
-const Minimap = ({ refreshMinimap }: MinimapProps) => {
+const MinimapContainer = ({ refreshMinimap, chatContainer, scrollContainer }: MinimapProps) => {
   const [scale, setScale] = useState<number>(0);
   const minimapContainerRef = useRef<HTMLDivElement>(null);
 
@@ -17,12 +16,10 @@ const Minimap = ({ refreshMinimap }: MinimapProps) => {
   }, [scale])
 
   useEffect(() => {
-    const scrollContainer = queryChatScrollContainer();
     const minimapContainer = minimapContainerRef.current;
     if (!scrollContainer) return;
     if (!minimapContainer) return;
     function onDrag(mousePos: number) {
-      const scrollContainer = queryChatScrollContainer();
       const minimapContainer = minimapContainerRef.current;
       if (!scrollContainer) return;
       if (!minimapContainer) return;
@@ -38,7 +35,6 @@ const Minimap = ({ refreshMinimap }: MinimapProps) => {
 
     function onScroll() {
       console.log("scrolling")
-      const scrollContainer = queryChatScrollContainer();
       const minimapContainer = minimapContainerRef.current;
       if (!scrollContainer) return;
       if (!minimapContainer) return;
@@ -51,7 +47,7 @@ const Minimap = ({ refreshMinimap }: MinimapProps) => {
         ratio * minimapContainer.offsetHeight;
     }
     scrollContainer.addEventListener("scroll", () => onScroll());
-  }, [refreshMinimap, scale]);
+  }, [refreshMinimap, scale, scrollContainer]);
 
   return (
     <div
@@ -59,8 +55,8 @@ const Minimap = ({ refreshMinimap }: MinimapProps) => {
       style={minimapContainerStyle}
       ref={minimapContainerRef}
     >
-      <CanvasContainer refreshCanvas={refreshMinimap} setScale={setScale} />
-      <ViewOverlay refreshCanvas={refreshMinimap} scale={scale} />
+      <CanvasContainer refreshCanvas={refreshMinimap} chatContainer={chatContainer} setScale={setScale} />
+      <ViewOverlay refreshCanvas={refreshMinimap} scrollContainer={scrollContainer} scale={scale} />
     </div>
   );
 };
@@ -77,5 +73,5 @@ const minimapContainerStyle: React.CSSProperties = {
 };
 
 
-export default Minimap;
+export default MinimapContainer;
 

--- a/src/components/MinimapContainer/ViewOverlay/ViewOverlay.tsx
+++ b/src/components/MinimapContainer/ViewOverlay/ViewOverlay.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from "react";
-import { queryChatScrollContainer } from "../../../utils/renderLogic";
 
 interface ViewOverLayProps {
   refreshCanvas: boolean;
   scale: number;
+  scrollContainer: HTMLElement|null;
 }
 
 export default function ViewOverlay({
   refreshCanvas,
   scale,
+  scrollContainer
 }: ViewOverLayProps) {
   const [scrollTop, setScrollTop] = useState(0);
   const [height, setHeight] = useState(0);
@@ -19,14 +20,13 @@ export default function ViewOverlay({
   }
 
   useEffect(() => {
-    const scrollContainer = queryChatScrollContainer();
     if (!scrollContainer) return; 
     onScroll(scrollContainer, scale)
     scrollContainer.addEventListener("scroll", (event) => {
       if (!(event.target instanceof HTMLElement)) return
       onScroll(event.target, scale)
   });
-  },[scale, refreshCanvas]);
+  },[scale, refreshCanvas, scrollContainer]);
 
   const currentViewStyle: React.CSSProperties = {
     position: "absolute",


### PR DESCRIPTION
I heard querying the dom multiple times in different places is bad. So instead i only query the chat and scroll containers at the top level then pass them down as props to the other elemenets