### PR TITLE
Add All Favourites tab and fix cross-provider navigation

### DIFF
--- a/components/all-favourites-list.tsx
+++ b/components/all-favourites-list.tsx
@@ -1,0 +1,121 @@
+import { Button } from "@/components/ui/button";
+import { favouritedChat } from "@/types";
+import { Copy, Download, ExternalLink, Trash } from "lucide-react";
+import { ICON_MAP } from "@/lib/chatgptElementUtils";
+import { cn } from "@/lib/utils";
+import useChatProvider from "@/hooks/use-chat-provider";
+import { toast } from "sonner";
+
+export default function AllFavouritesList({
+  favourites,
+  setFavourites,
+  onClose
+}: {
+  favourites: Record<string, favouritedChat>,
+  setFavourites: CallableFunction,
+  onClose: () => void
+}) {
+  const chatProvider = useChatProvider()
+
+  const exportToClipboard = () => {
+    navigator.clipboard.writeText(JSON.stringify(favourites, null, 2))
+    toast.success("Copied to clipboard")
+  }
+
+  const exportToFile = () => {
+    const blob = new Blob([JSON.stringify(favourites, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `chat-gps-favourites-${new Date().toISOString().split('T')[0]}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    toast.success("Exported to file")
+  }
+
+  const removeFavourite = (uniqueId: string) => {
+      setFavourites((old: Record<string, favouritedChat>) => {
+        const newFavs = { ...old }
+        delete newFavs[uniqueId]
+        return newFavs
+      })
+  }
+
+  // Group favourites by chatId
+  const groupedFavourites: Record<string, { favs: { id: string, data: favouritedChat }[] }> = {}
+  Object.entries(favourites).forEach(([key, value]) => {
+      if (!groupedFavourites[value.chatId]) {
+          groupedFavourites[value.chatId] = { favs: [] }
+      }
+      groupedFavourites[value.chatId].favs.push({ id: key, data: value })
+  })
+
+  const getChatUrl = (chatId: string, fav: favouritedChat) => {
+      if (fav.url) return fav.url;
+      // Fallback for legacy items (assume chatgpt)
+      return `https://chat.com/c/${chatId}`;
+  }
+
+  return (
+    <div className="w-full h-full flex flex-col bg-background">
+      <div className="flex justify-between items-center p-2 border-b">
+        <h2 className="font-bold">All Favourites</h2>
+        <div className="flex gap-1">
+             <Button size="sm" variant="outline" onClick={exportToClipboard} title="Copy to Clipboard">
+                <Copy size={14} />
+             </Button>
+             <Button size="sm" variant="outline" onClick={exportToFile} title="Export to JSON">
+                <Download size={14} />
+             </Button>
+             <Button size="sm" variant="ghost" onClick={onClose}>Back</Button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2">
+         {Object.keys(groupedFavourites).length === 0 ? (
+             <div className="text-center text-muted-foreground p-4">No favourites yet.</div>
+         ) : (
+             Object.entries(groupedFavourites).map(([chatId, { favs }]) => {
+                 // Use the first fav to guess the URL if possible, or just link to the generic chat
+                 const firstFav = favs[0].data;
+                 const chatUrl = getChatUrl(chatId, firstFav);
+
+                 return (
+                 <div key={chatId} className="mb-4 border rounded-md overflow-hidden">
+                     <div className="bg-muted p-2 text-xs font-semibold break-all border-b flex justify-between items-center">
+                        <span>Chat ID: {chatId}</span>
+                        <a href={chatUrl} target="_blank" className="hover:text-primary">
+                            <ExternalLink size={12} />
+                        </a>
+                     </div>
+                     <div className="flex flex-col">
+                         {favs.map(({ id, data }) => (
+                             <div key={id} className="p-2 border-b last:border-b-0 flex items-center justify-between gap-2 hover:bg-muted/50">
+                                 <div className="flex items-center gap-2 overflow-hidden">
+                                     {ICON_MAP[data.iconName] ?
+                                        (() => { const Icon = ICON_MAP[data.iconName]; return <Icon size={14} className="shrink-0"/> })()
+                                        : null
+                                     }
+                                     <span className="text-xs truncate">{data.preview}</span>
+                                 </div>
+                                 <div className="flex gap-1 shrink-0">
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+                                        onClick={() => removeFavourite(id)}
+                                    >
+                                        <Trash size={12} />
+                                    </Button>
+                                 </div>
+                             </div>
+                         ))}
+                     </div>
+                 </div>
+             )})
+         )}
+      </div>
+    </div>
+  )
+}

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -11,7 +11,7 @@
     * remove a tonne of code
     * add export chat button?
 * what I did:
-    * find out what others were doing. 
+    * find out what others were doing.
     * removed fav section for now
     * added search to filter
     * made it an overlay, deleted old components.
@@ -37,9 +37,9 @@
 
 
 ## 2026-01-25
-* git: 
+* git:
 * start: 09:39
-* end: 
+* end:
 * what I want to do:
     * simplifiy logic in `App.tsx`
     * add back in favourites

--- a/hooks/use-theme-detection.ts
+++ b/hooks/use-theme-detection.ts
@@ -1,3 +1,5 @@
+import { useTheme } from "@/components/theme-provider";
+
 /**
  * Detects the theme on the page and updates the theme for the extension.
  */
@@ -6,29 +8,42 @@ export default function useThemeDetection() {
 
   useEffect(() => {
     const checkAndSetTheme = () => {
-      const rootElement = document.body;
-      const rootBackgroundColor = window.getComputedStyle(rootElement).backgroundColor;
-      
+      let rootElement = document.documentElement;
+      let rootBackgroundColor = window.getComputedStyle(rootElement).backgroundColor;
+
+      // Check for transparency (rgba(0, 0, 0, 0) or 'transparent')
+      if (rootBackgroundColor === 'rgba(0, 0, 0, 0)' || rootBackgroundColor === 'transparent') {
+        // Fallback to body
+        rootElement = document.body;
+        rootBackgroundColor = window.getComputedStyle(rootElement).backgroundColor;
+      }
+
+      // If still transparent, default to light mode
+      if (rootBackgroundColor === 'rgba(0, 0, 0, 0)' || rootBackgroundColor === 'transparent') {
+        setTheme("light");
+        return;
+      }
+
       // Extract RGB values
       const rgbMatch = rootBackgroundColor.match(/\d+/g);
       if (!rgbMatch || rgbMatch.length < 3) return;
-      
+
       const [r, g, b] = rgbMatch.slice(0, 3).map(Number);
-      
+
       // Calculate relative luminance (standard formula)
       const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-      
+
       // Use 0.5 threshold for relative luminance
       const isDarkMode = luminance < 0.5;
       setTheme(isDarkMode ? "dark" : "light");
     };
 
     checkAndSetTheme();
-    
+
     const observer = new MutationObserver(checkAndSetTheme);
-    observer.observe(document.documentElement, { 
-      attributes: true, 
-      attributeFilter: ["style", "class"] 
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["style", "class"]
     });
 
     return () => observer.disconnect();

--- a/lib/chatgptElementUtils.ts
+++ b/lib/chatgptElementUtils.ts
@@ -86,13 +86,23 @@ const LANGUAGE_MAP: ReactComponentMap = {
   "bash": BiTerminal,
 }
 
-const ICON_MAP: ReactComponentMap = {
+export const ICON_MAP: ReactComponentMap = {
   "user": User,
   "assistant": BotMessageSquare,
   "code": Code,
   "section": Section,
   "chat": MessageSquare,
   ...LANGUAGE_MAP
+}
+
+export function extractChatId(url: string): string {
+  // Simple implementation: use the path as ID (ignoring query params/hash for uniqueness of the chat resource)
+  try {
+    const urlObj = new URL(url);
+    return urlObj.pathname;
+  } catch (e) {
+    return url;
+  }
 }
 
 export function queryAllUserChats(scrollContainer: HTMLElement, selectorMap: Record<string, string>): HTMLElement[] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chat-gps",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chat-gps",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "@emailjs/browser": "^4.4.1",

--- a/types.ts
+++ b/types.ts
@@ -8,6 +8,7 @@ export interface favouritedChat {
   chatId: string,
   scrollTop: number,
   preview: string,
+  url: string,
 }
 
 


### PR DESCRIPTION
- Implemented `AllFavouritesList` component to view, manage, and export all favourites.
- Added "View all favourites" button to the overlay header.
- Updated `favouritedChat` type to store the full URL, ensuring correct navigation across different providers (ChatGPT, Claude, Gemini).
- Updated `ChatOutline` to save the URL when favouriting.
- Updated navigation logic to use the stored URL.
- Added export to clipboard and JSON file functionality.

Co-authored-by: berkan <644686+berkan@users.noreply.github.com>